### PR TITLE
Ignore comments in activity view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore comments in activity view.
+  Fixes a bug where the activity view crashed when comments were added.
+  [jone]
 
 
 1.1.0 (2014-09-04)

--- a/ftw/activity/browser/representations.py
+++ b/ftw/activity/browser/representations.py
@@ -7,6 +7,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import adapts
 from zope.component import getUtility
+from zope.component import queryAdapter
 from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
@@ -48,7 +49,10 @@ class DefaultRepresentation(object):
             'member': member}
 
     def get_last_modifier(self):
-        return ILastModifier(self.context).get()
+        modifier = queryAdapter(self.context, ILastModifier)
+        if modifier is None:
+            return None
+        return modifier.get()
 
     def portal_type(self):
         portal_types = getToolByName(self.context, 'portal_types')


### PR DESCRIPTION
Fixes a bug where the activity view crashed when comments were added.

Fixes #2 
