### PR TITLE
Bugfix if user is not available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes a bug where the activity view crashed when the modifying user is no
+  longer available.
+  [mbaechtold]
 
 
 1.1.2 (2014-09-24)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(name='ftw.activity',
         'collective.prettydate',
         'ftw.upgrade',
         'setuptools',
+        'plone.api',
         ],
 
       tests_require=tests_require,


### PR DESCRIPTION
Bugfix: prevent an error while rendering the activity stream if the user is not available.

This might happen if you're working with data from a site where a directory service is configured but for some reason you cannot connect to it and thus the user cannot be fetched.
