### PR TITLE
Fix diazo error when fetching more events.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
+- Fix diazo error when fetching more events.
+  [jone]
+
 - disable diazo themeing for ajax responses.
   [jone]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- disable diazo themeing for ajax responses.
+  [jone]
 
 
 1.1.4 (2015-03-25)

--- a/ftw/activity/browser/activity.py
+++ b/ftw/activity/browser/activity.py
@@ -18,6 +18,7 @@ class ActivityView(BrowserView):
         """Action for retrieving more events (based on `last_uid` in
         the request) with AJAX.
         """
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
         return self.events_template()
 
     def raw(self):

--- a/ftw/activity/browser/activity.py
+++ b/ftw/activity/browser/activity.py
@@ -19,7 +19,10 @@ class ActivityView(BrowserView):
         the request) with AJAX.
         """
         self.request.response.setHeader('X-Theme-Disabled', 'True')
-        return self.events_template()
+        # The HTML stripped in order to have empty response content when
+        # there are no tags at all, so that diazo does not try to
+        # parse it.
+        return self.events_template().strip()
 
     def raw(self):
         """Action for embedding activity stream into another view.


### PR DESCRIPTION
The problem is that diazo (even when disabled) tries to parse the response body.
If the body is empty (no more events), diazo throws an error while trying to access
the document root node.
By stripping the HTML, the content is an empty string and diazo tries no longer to parse it.