### PR TITLE
Add IActivityCreatedEvent.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,26 @@ the default activity macro and extend it:
   </metal:wrapper>
 
 
+Store additional information on activities
+==========================================
+
+The metadata stored on the activity record can be easily extended with an event handler:
+
+.. code:: ZCML
+
+    <subscriber
+        for="ftw.activity.interfaces.IActivityCreatedEvent"
+        handler=".subscribers.enhance_activity_record"
+        />
+
+.. code:: python
+
+    def enhance_activity_record(event):
+        record = event.activity
+        obj = event.object
+        record.attrs['creator'] = obj.Creator()
+
+
 Links
 =====
 

--- a/ftw/activity/catalog/record.py
+++ b/ftw/activity/catalog/record.py
@@ -1,11 +1,13 @@
 from AccessControl import getSecurityManager
 from collective.prettydate.interfaces import IPrettyDate
 from DateTime import DateTime
+from ftw.activity.events import ActivityCreatedEvent
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from souper.soup import Record
 from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.event import notify
 from zope.i18n import translate
 
 
@@ -20,6 +22,8 @@ class ActivityRecord(Record):
         self.attrs['actor'] = (actor_userid
                                or getSecurityManager().getUser().getId())
         self.attrs['date'] = date or DateTime()
+
+        notify(ActivityCreatedEvent(context, self))
 
     def get_object(self):
         reference_catalog = getToolByName(getSite(), 'reference_catalog')

--- a/ftw/activity/events.py
+++ b/ftw/activity/events.py
@@ -1,0 +1,15 @@
+from ftw.activity.interfaces import IActivityCreatedEvent
+from zope.component.interfaces import ObjectEvent
+from zope.interface import implements
+
+
+class ActivityCreatedEvent(ObjectEvent):
+    """An activity has been created.
+    """
+
+    implements(IActivityCreatedEvent)
+
+    def __init__(self, obj, activity):
+        super(ActivityCreatedEvent, self).__init__(obj)
+        self.activity = activity
+        self.action = activity.attrs['action']

--- a/ftw/activity/interfaces.py
+++ b/ftw/activity/interfaces.py
@@ -1,3 +1,5 @@
+from zope.component.interfaces import IObjectEvent
+from zope.interface import Attribute
 from zope.interface import Interface
 
 
@@ -49,3 +51,10 @@ class IActivityRenderer(Interface):
     def render(activity, obj):
         """Renders the activity.
         """
+
+class IActivityCreatedEvent(IObjectEvent):
+    """The activity created event is fired when a new activity record is created.
+    """
+
+    activity = Attribute('The activity record.')
+    action = Attribute('The activity action.')

--- a/ftw/activity/testing.py
+++ b/ftw/activity/testing.py
@@ -1,16 +1,16 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from zope.configuration import xmlconfig
 import ftw.activity.tests.builders
 
 
 class ActivityLayer(PloneSandboxLayer):
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         xmlconfig.string(


### PR DESCRIPTION
:construction: based on #8 (rebase needed)

The IActivityCreatedEvent allows to easily enhance the information stored on the activity record for later rendering, without changing the code of ftw.activity.
