### PR TITLE
Add filter mechanism and close changes filter

### DIFF
--- a/ftw/activity/configure.zcml
+++ b/ftw/activity/configure.zcml
@@ -45,6 +45,9 @@
         handler=".hooks.uninstalled"
         />
 
+    <adapter factory=".filters.FilterCloseChanges"
+             name="ftw.activity:filter-close-changes" />
+
     <!-- archetypes -->
     <subscriber
         for="Products.Archetypes.interfaces.IBaseObject

--- a/ftw/activity/filters.py
+++ b/ftw/activity/filters.py
@@ -1,0 +1,48 @@
+from datetime import timedelta
+from ftw.activity.interfaces import IActivityFilter
+from zope.component import adapts
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class FilterCloseChanges(object):
+    """This filter removes "changed"-activities when they occur
+    in short time on the same object.
+    """
+
+    implements(IActivityFilter)
+    adapts(Interface, Interface, Interface)
+
+    time_threshold = timedelta(minutes=1)
+
+    def __init__(self, context, request, view):
+        self.context = context
+        self.request = request
+        self.view = view
+
+    def position(self):
+        return 100
+
+    def process(self, activities):
+        previous = None
+        for activity in activities:
+            if self.show_activity(activity, previous):
+                yield activity
+            previous = activity
+
+    def show_activity(self, this, newer):
+        if not newer:
+            return True
+
+        if this.attrs['action'] != 'changed' or newer.attrs['action'] != 'changed':
+            return True
+
+        if this.attrs['uuid'] != newer.attrs['uuid']:
+            return True
+
+        if this.attrs['actor'] != newer.attrs['actor']:
+            return True
+
+        this_date = this.attrs['date'].asdatetime()
+        newer_date = newer.attrs['date'].asdatetime()
+        return this_date < newer_date - self.time_threshold

--- a/ftw/activity/interfaces.py
+++ b/ftw/activity/interfaces.py
@@ -52,9 +52,47 @@ class IActivityRenderer(Interface):
         """Renders the activity.
         """
 
+
 class IActivityCreatedEvent(IObjectEvent):
     """The activity created event is fired when a new activity record is created.
     """
 
     activity = Attribute('The activity record.')
     action = Attribute('The activity action.')
+
+
+class IActivityFilter(Interface):
+    """An activity filter can filter activities so that they do not appear
+    in the activity view.
+
+    The filters are chained into a pipeline of filters, each filter can drop any
+    activity based on its own conditions.
+
+    The filters should be implemented as generators because of performance.
+
+    The filters are ordered by their ``position`` in the pipeline.
+
+    Each activity filter is a named multi-adapter, adapting context, request and
+    the activity view.
+    """
+
+    def __init__(context, request, view):
+        """Adapts a context, request and view.
+        """
+
+    def position():
+        """The position of this filter in the pipeline.
+        This should be a positive integer.
+        Small numbers will lead in an early position in the pipeline.
+        """
+
+    def process(activities):
+        """The process method is called with a iterable (generator) of activity records.
+        The method is expected to yield all activities which should be kept and drop
+        unwanted activites by doing nothing with them.
+
+        The process method may try to get the object of each activity.
+        The method should be implemented as generator, otherwise it will break the lazy
+        batching and result in processing all activities, even when they are not rendered
+        because of the batching.
+        """

--- a/ftw/activity/tests/test_filters.py
+++ b/ftw/activity/tests/test_filters.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from ftw.activity.filters import FilterCloseChanges
+from ftw.activity.interfaces import IActivityFilter
+from ftw.activity.testing import FUNCTIONAL_TESTING
+from ftw.activity.tests.pages import activity
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from operator import attrgetter
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from Products.Archetypes.event import ObjectEditedEvent
+from unittest2 import TestCase
+from zope.event import notify
+from zope.interface.verify import verifyClass
+import transaction
+
+
+class TestCloseChangesFilters(TestCase):
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+
+    def test_implements_interface_correctly(self):
+        verifyClass(IActivityFilter, FilterCloseChanges)
+
+    @browsing
+    def test_removes_concurrent_changes_in_less_than_1_minute(self, browser):
+        with freeze(datetime(2010, 1, 1, 2, 0)) as clock:
+            page = create(Builder('page'))
+
+            for _ in range(10):
+                clock.forward(seconds=45)
+                notify(ObjectEditedEvent(page))
+
+            clock.forward(hours=1)
+            notify(ObjectEditedEvent(page))
+            transaction.commit()
+
+            browser.login().open(view='activity')
+            self.assertEquals(
+                ['Document changed now by test_user_1_',
+                 'Document changed an hour ago by test_user_1_',
+                 'Document added an hour ago by test_user_1_'],
+                map(attrgetter('byline'), activity.events()))


### PR DESCRIPTION
Adds a filtering mechanism with a default filter for removing succeeding similar "changed" activities on the same object in short time, so that the activity stream is not flooded with activities.