### PR TITLE
Implement "View" security checks for records.

### DIFF
--- a/ftw/activity/browser/activity.py
+++ b/ftw/activity/browser/activity.py
@@ -1,4 +1,4 @@
-from ftw.activity.catalog import get_activity_soup
+from ftw.activity.catalog import query_soup
 from ftw.activity.interfaces import IActivityFilter
 from ftw.activity.interfaces import IActivityRenderer
 from operator import itemgetter
@@ -51,8 +51,7 @@ class ActivityView(BrowserView):
         return Eq('path', '/'.join(self.context.getPhysicalPath()))
 
     def _lookup(self):
-        soup = get_activity_soup()
-        return soup.query(self.query(), sort_index='date', reverse=True)
+        return query_soup(self.query(), sort_index='date', reverse=True)
 
     def _begin_after(self, last_activity, activities):
         found = False

--- a/ftw/activity/browser/templates/activity_macros.pt
+++ b/ftw/activity/browser/templates/activity_macros.pt
@@ -52,11 +52,11 @@
 
             by
 
-            <span i18n:name="actor" class="actor">
-                <a tal:attributes="href actor/url"
-                   tal:omit-tag="not:actor/url"
-                   tal:content="actor/fullname" />
-            </span>
+            <span
+                i18n:name="actor" class="actor"><a
+                tal:attributes="href actor/url"
+                tal:omit-tag="not:actor/url"
+                tal:content="actor/fullname" /></span>
         </metal:BYLINE>
     </div>
 

--- a/ftw/activity/catalog/__init__.py
+++ b/ftw/activity/catalog/__init__.py
@@ -1,6 +1,11 @@
 from collective.lastmodifier.interfaces import ILastModifier
 from ftw.activity.catalog.record import ActivityRecord
+from ftw.activity.utils import get_roles_and_users
+from functools import partial
 from plone.uuid.interfaces import IUUID
+from repoze.catalog.query import And
+from repoze.catalog.query import Eq
+from repoze.catalog.query import Or
 from souper.soup import get_soup
 from zope.component import queryAdapter
 from zope.component.hooks import getSite
@@ -8,7 +13,13 @@ from zope.component.hooks import getSite
 
 def query_soup(queryobject, **kwargs):
     soup = get_activity_soup()
+    queryobject = And(make_allowed_roles_and_users_query(),
+                      queryobject)
     return soup.query(queryobject, **kwargs)
+
+
+def make_allowed_roles_and_users_query(index=u'allowed_roles_and_users'):
+    return reduce(Or, map(partial(Eq, index), get_roles_and_users()))
 
 
 def get_activity_soup():

--- a/ftw/activity/catalog/__init__.py
+++ b/ftw/activity/catalog/__init__.py
@@ -6,6 +6,11 @@ from zope.component import queryAdapter
 from zope.component.hooks import getSite
 
 
+def query_soup(queryobject, **kwargs):
+    soup = get_activity_soup()
+    return soup.query(queryobject, **kwargs)
+
+
 def get_activity_soup():
     return get_soup('activity', getSite())
 

--- a/ftw/activity/catalog/factory.py
+++ b/ftw/activity/catalog/factory.py
@@ -1,9 +1,11 @@
+from ftw.activity.interfaces import IActivitySoupCatalogFactoryExtension
 from repoze.catalog.catalog import Catalog
 from repoze.catalog.indexes.field import CatalogFieldIndex
-from repoze.catalog.indexes.path import CatalogPathIndex
 from repoze.catalog.indexes.keyword import CatalogKeywordIndex
+from repoze.catalog.indexes.path import CatalogPathIndex
 from souper.interfaces import ICatalogFactory
 from souper.soup import NodeAttributeIndexer
+from zope.component import getAdapters
 from zope.interface import implements
 
 
@@ -21,4 +23,9 @@ class ActivitySoupCatalogFactory(object):
         catalog[u'action'] = CatalogFieldIndex(NodeAttributeIndexer(u'action'))
         catalog[u'actor'] = CatalogFieldIndex(NodeAttributeIndexer(u'actor'))
         catalog[u'date'] = CatalogFieldIndex(NodeAttributeIndexer(u'date'))
+
+        for name, adapter in sorted(getAdapters(
+                (catalog,), IActivitySoupCatalogFactoryExtension)):
+            adapter()
+
         return catalog

--- a/ftw/activity/catalog/factory.py
+++ b/ftw/activity/catalog/factory.py
@@ -1,6 +1,7 @@
 from repoze.catalog.catalog import Catalog
 from repoze.catalog.indexes.field import CatalogFieldIndex
 from repoze.catalog.indexes.path import CatalogPathIndex
+from repoze.catalog.indexes.keyword import CatalogKeywordIndex
 from souper.interfaces import ICatalogFactory
 from souper.soup import NodeAttributeIndexer
 from zope.interface import implements
@@ -11,6 +12,8 @@ class ActivitySoupCatalogFactory(object):
 
     def __call__(self, context=None):
         catalog = Catalog()
+        catalog[u'allowed_roles_and_users'] = CatalogKeywordIndex(
+            NodeAttributeIndexer(u'allowed_roles_and_users'))
         catalog[u'path'] = CatalogPathIndex(NodeAttributeIndexer(u'path'))
         catalog[u'uuid'] = CatalogFieldIndex(NodeAttributeIndexer(u'uuid'))
         catalog[u'portal_type'] = CatalogFieldIndex(NodeAttributeIndexer(

--- a/ftw/activity/catalog/record.py
+++ b/ftw/activity/catalog/record.py
@@ -2,6 +2,7 @@ from AccessControl import getSecurityManager
 from collective.prettydate.interfaces import IPrettyDate
 from DateTime import DateTime
 from ftw.activity.events import ActivityCreatedEvent
+from ftw.activity.utils import roles_and_users_for_permission
 from plone.app.uuid.utils import uuidToObject
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
@@ -15,6 +16,8 @@ from zope.i18n import translate
 class ActivityRecord(Record):
 
     def __init__(self, context, action, actor_userid=None, date=None):
+        self.attrs['allowed_roles_and_users'] = (
+            roles_and_users_for_permission(context, 'View'))
         self.attrs['path'] = '/'.join(context.getPhysicalPath())
         self.attrs['uuid'] = IUUID(context)
         self.attrs['portal_type'] = context.portal_type

--- a/ftw/activity/interfaces.py
+++ b/ftw/activity/interfaces.py
@@ -97,3 +97,18 @@ class IActivityFilter(Interface):
         the lazy batching and result in processing all activities, even when
         they are not rendered because of the batching.
         """
+
+
+class IActivitySoupCatalogFactoryExtension(Interface):
+    """Adapter interface for extending the catalog factory.
+    The **named** adapter adapts the repoze catalog
+    (repoze.catalog.interfaces.ICatalog) and may add additional indexes.
+    """
+
+    def __init__(catalog):
+        """Adapts the catalog.
+        """
+
+    def __call__():
+        """Extend the catalog with indexes.
+        """

--- a/ftw/activity/tests/helpers.py
+++ b/ftw/activity/tests/helpers.py
@@ -1,4 +1,4 @@
-from ftw.activity.catalog import get_activity_soup
+from ftw.activity.catalog import query_soup
 from repoze.catalog.query import Eq
 from zope.component.hooks import getSite
 
@@ -9,6 +9,6 @@ def get_soup_activities(attributes=('path', 'action')):
         lambda record: dict((key, value) for (key, value)
                             in record.attrs.items()
                             if key in attributes),
-        get_activity_soup().query(Eq('path', portal_path),
-                                  sort_index='date',
-                                  reverse=False))
+        query_soup(Eq('path', portal_path),
+                   sort_index='date',
+                   reverse=False))

--- a/ftw/activity/tests/test_catalog.py
+++ b/ftw/activity/tests/test_catalog.py
@@ -4,6 +4,7 @@ from ftw.activity.catalog import get_activity_soup
 from ftw.activity.catalog import object_added
 from ftw.activity.catalog import object_changed
 from ftw.activity.catalog import object_deleted
+from ftw.activity.catalog import query_soup
 from ftw.activity.testing import FUNCTIONAL_TESTING
 from ftw.builder import Builder
 from ftw.builder import create
@@ -82,7 +83,7 @@ class TestCatalog(TestCase):
             object_changed(document)
 
         results = map(lambda record: (record.attrs['action'], record.attrs['date']),
-                      soup.query(Eq('action', 'changed'),
+                      query_soup(Eq('action', 'changed'),
                                  sort_index='date',
                                  reverse=True))
 
@@ -100,7 +101,7 @@ class TestCatalog(TestCase):
         map(object_added, (folder, doc1, doc2))
 
         results = map(lambda record: record.attrs['path'],
-                      soup.query(Eq('path', '/'.join(folder.getPhysicalPath()))))
+                      query_soup(Eq('path', '/'.join(folder.getPhysicalPath()))))
 
         self.assertItemsEqual(['/plone/folder', '/plone/folder/one'],
                               results)

--- a/ftw/activity/tests/test_record.py
+++ b/ftw/activity/tests/test_record.py
@@ -114,3 +114,11 @@ class TestCatalog(TestCase):
     def test_translated_portal_type(self):
         record = ActivityRecord(create(Builder('document')), 'added')
         self.assertEquals('Document', record.translated_portal_type())
+
+    def test_allowed_roles_and_users(self):
+        self.portal.manage_permission('View', ['Reader', 'Manager'])
+        create(Builder('user').with_roles('Reader', on=self.portal))
+        record = ActivityRecord(create(Builder('document')), 'added')
+        self.assertEquals(
+            ['user:john.doe', 'Manager', 'Reader'],
+            record.attrs['allowed_roles_and_users'])

--- a/ftw/activity/tests/test_utils.py
+++ b/ftw/activity/tests/test_utils.py
@@ -1,0 +1,132 @@
+from ftw.activity.testing import FUNCTIONAL_TESTING
+from ftw.activity.utils import get_roles_and_users
+from ftw.activity.utils import roles_and_users_for_permission
+from ftw.builder import Builder
+from ftw.builder import create
+from plone.app.testing import login
+from plone.app.testing import logout
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+
+
+PERMISSION = 'FTP access'
+
+
+class TestRolesAndUsersForPermission(TestCase):
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    def test_includes_global_roles(self):
+        self.portal.manage_permission(PERMISSION, ['Contributor', 'Reader'],
+                                      acquire=False)
+        page = create(Builder('page'))
+        self.assertEquals(
+            ['Contributor', 'Reader'],
+            roles_and_users_for_permission(page, PERMISSION))
+
+    def test_includes_local_roles(self):
+        self.portal.manage_permission(PERMISSION, [], acquire=False)
+        page = create(Builder('page'))
+        page.manage_permission(PERMISSION, ['Reader'])
+        create(Builder('user').with_roles('Reader', on=page))
+        self.assertEquals(
+            ['user:john.doe', 'Reader'],
+            roles_and_users_for_permission(page, PERMISSION))
+
+    def test_includes_inherited_local_roles(self):
+        self.portal.manage_permission(PERMISSION, [], acquire=False)
+        parent = create(Builder('folder'))
+        parent.manage_permission(PERMISSION, ['Reader'])
+        create(Builder('user').with_roles('Reader', on=parent))
+        child = create(Builder('page').within(parent))
+        self.assertEquals(
+            ['user:john.doe', 'Reader'],
+            roles_and_users_for_permission(child, PERMISSION))
+
+    def test_respects_block_inheriting_local_roles(self):
+        self.portal.manage_permission(PERMISSION, [], acquire=False)
+        parent = create(Builder('folder'))
+        parent.manage_permission(PERMISSION, ['Reader'])
+        create(Builder('user').with_roles('Reader', on=parent))
+        child = create(Builder('page').within(parent))
+        child.__ac_local_roles_block__ = True
+        self.assertEquals(
+            ['Reader'],
+            roles_and_users_for_permission(child, PERMISSION))
+
+    def test_supports_groups(self):
+        self.portal.manage_permission(PERMISSION, [], acquire=False)
+        page = create(Builder('page'))
+        page.manage_permission(PERMISSION, ['Reader'])
+        create(Builder('group')
+               .titled('Does')
+               .with_roles('Reader', on=page)
+               .with_members(create(Builder('user'))))
+        self.assertEquals(
+            ['user:does', 'Reader'],
+            roles_and_users_for_permission(page, PERMISSION))
+
+    def test_merges_to_anonymous_when_possible(self):
+        # All users have the Anonymous role, therefore we don't need
+        # to resolve roles and users when Anonymous has the permission.
+        self.portal.manage_permission(PERMISSION, ['Anonymous', 'Reader'])
+        page = create(Builder('page'))
+        create(Builder('user').with_roles('Reader', on=page))
+        self.assertEquals(
+            ['Anonymous'],
+            roles_and_users_for_permission(page, PERMISSION))
+
+    def test_merges_to_authenticated_when_possible(self):
+        # All users have the Authenticated role, therefore we don't need
+        # to resolve roles and users when Authenticated has the permission.
+        self.portal.manage_permission(PERMISSION, ['Authenticated', 'Reader'])
+        page = create(Builder('page'))
+        create(Builder('user').with_roles('Reader', on=page))
+        self.assertEquals(
+            ['Authenticated'],
+            roles_and_users_for_permission(page, PERMISSION))
+
+
+class TestGetRolesAndUsers(TestCase):
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_anonymous_users_get_anonymous_role_only(self):
+        logout()
+        self.assertEquals(['Anonymous'], get_roles_and_users())
+
+    def test_includes_userid(self):
+        john = create(Builder('user'))
+        login(self.portal, john.getId())
+        self.assertIn('user:john.doe', get_roles_and_users())
+
+    def test_includes_global_roles(self):
+        setRoles(self.portal, TEST_USER_ID, ['Manager', 'Contributor'])
+        self.assertEquals(['Authenticated',
+                           'user:AuthenticatedUsers',
+                           'user:test_user_1_',
+                           'Manager',
+                           'Anonymous',
+                           'Contributor'], get_roles_and_users())
+
+    def test_includes_group_ids(self):
+        john = create(Builder('user'))
+        create(Builder('group').titled('Does').with_members(john))
+        login(self.portal, john.getId())
+        self.assertIn('user:does', get_roles_and_users())
+
+    def test_always_includes_authenticated(self):
+        john = create(Builder('user'))
+        login(self.portal, john.getId())
+        self.assertIn('Authenticated', get_roles_and_users())
+
+    def test_always_includes_anonymous(self):
+        john = create(Builder('user'))
+        login(self.portal, john.getId())
+        self.assertIn('Anonymous', get_roles_and_users())

--- a/ftw/activity/utils.py
+++ b/ftw/activity/utils.py
@@ -1,0 +1,42 @@
+from AccessControl.PermissionRole import rolesForPermissionOn
+from Acquisition import aq_base
+from Products.CMFCore.utils import getToolByName
+import AccessControl
+
+
+def roles_and_users_for_permission(obj, permission):
+    """Returns a list of roles and users with a specific permission.
+    """
+    acl_users = getToolByName(obj, 'acl_users')
+
+    allowed_roles = set(rolesForPermissionOn(permission, obj))
+    if 'Anonymous' in allowed_roles:
+        return ['Anonymous']
+    if 'Authenticated' in allowed_roles:
+        return ['Authenticated']
+
+    result = set(allowed_roles)
+
+    for user, roles in acl_users._getAllLocalRoles(obj).items():
+        if set(roles) & allowed_roles:
+            result.add('user:' + user)
+
+    if 'Owner' in result:
+        result.remove('Owner')
+    return list(result)
+
+
+def get_roles_and_users():
+    """Return the roles and users values for the current user,
+    which can be used to query against a roles_and_users index.
+    """
+    user = AccessControl.getSecurityManager().getUser()
+    if user == AccessControl.SpecialUsers.nobody:
+        return ['Anonymous']
+
+    result = set(['Anonymous'])
+    result.update(user.getRoles())
+    result.add('user:{}'.format(user.getId()))
+    if hasattr(aq_base(user), 'getGroups'):
+        result.update(map('user:{}'.format, user.getGroups()))
+    return list(result)


### PR DESCRIPTION
Similarily to the portal_catalog, the View security checks are done with an allowed_roles_and_users index.
All queries are extended with allowed_roles_and_users checks.
