### PR TITLE
local activity view.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,14 @@ of the same object which happen in less than 1 Minute between each activity.
 This is removes noise from the activity feed when a user edits the same object a lot in short
 time, for example when using an external editor.
 
+
+Local activity view
+===================
+
+The ``@@local-activity`` view is available on any context and shows only activities
+of the current context but not its children.
+
+
 Links
 =====
 

--- a/ftw/activity/browser/configure.zcml
+++ b/ftw/activity/browser/configure.zcml
@@ -27,4 +27,14 @@
 
     <adapter factory=".renderer.DefaultRenderer" name="default" />
 
+    <browser:page
+        for="*"
+        name="local-activity"
+        class=".local.LocalActivityView"
+        permission="zope2.View"
+        allowed_attributes="fetch raw"
+        />
+
+    <adapter factory=".local.LocalActivityFilter" name="local-activity-filter" />
+
 </configure>

--- a/ftw/activity/browser/local.py
+++ b/ftw/activity/browser/local.py
@@ -1,0 +1,41 @@
+from ftw.activity.browser.activity import ActivityView
+from ftw.activity.interfaces import IActivityFilter
+from ftw.activity.interfaces import ILocalActivityView
+from zope.component import adapts
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class LocalActivityView(ActivityView):
+    implements(ILocalActivityView)
+
+
+class LocalActivityFilter(object):
+    """This filters all activities of contents which are not the
+    current context but within the current context.
+
+    This means we are breaking the default recursivity of the souper
+    catalog.
+
+    The problem is that a Eq('path', path) query is recursive and
+    the index is not able to do a non-recursive query with the path
+    index.
+    """
+
+    implements(IActivityFilter)
+    adapts(Interface, Interface, ILocalActivityView)
+
+    def __init__(self, context, request, view):
+        self.context = context
+        self.request = request
+        self.view = view
+
+    def position(self):
+        return 50
+
+    def process(self, activities):
+        path = '/'.join(self.context.getPhysicalPath())
+        for activity in activities:
+            if activity.attrs['path'] != path:
+                continue
+            yield activity

--- a/ftw/activity/interfaces.py
+++ b/ftw/activity/interfaces.py
@@ -112,3 +112,8 @@ class IActivitySoupCatalogFactoryExtension(Interface):
     def __call__():
         """Extend the catalog with indexes.
         """
+
+
+class ILocalActivityView(Interface):
+    """Marker interface for the local-activity view.
+    """

--- a/ftw/activity/tests/test_local_activity_view.py
+++ b/ftw/activity/tests/test_local_activity_view.py
@@ -1,0 +1,27 @@
+from ftw.activity.testing import FUNCTIONAL_TESTING
+from ftw.activity.tests.pages import activity
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from operator import attrgetter
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+
+
+
+class TestActivityView(TestCase):
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+
+    @browsing
+    def test_local_activity_view_is_not_recursive(self, browser):
+        folder = create(Builder('folder').titled('The Folder'))
+        create(Builder('file').titled('The First File'))
+
+        browser.login().open(folder, view='local-activity')
+        self.assertEquals(
+            ['The Folder'],
+            map(attrgetter('title'), activity.events()))


### PR DESCRIPTION
The default @@activity view is always recursive.
The @@local-activity shows only activities for the current context but not its children.