### PR TITLE
Fix fetching within tabbedview tabs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Fix fetching within tabbedview tabs.
+  [jone]
+
 - Add an Activity Portlet
   [elioschmutz]
 

--- a/ftw/activity/browser/configure.zcml
+++ b/ftw/activity/browser/configure.zcml
@@ -16,6 +16,7 @@
         name="tabbedview_view-activity"
         class=".tab.ActivityTab"
         permission="zope2.View"
+        allowed_attributes="fetch raw"
         />
 
     <browser:page

--- a/ftw/activity/browser/templates/activity_raw.pt
+++ b/ftw/activity/browser/templates/activity_raw.pt
@@ -2,7 +2,7 @@
 
   <div class="activity">
     <div class="events"
-         tal:attributes="data-fetch-url fetch_url|string:${context/@@plone_context_state/current_base_url}/fetch"
+         tal:attributes="data-fetch-url fetch_url|string:${context/absolute_url}/${view/__name__}/fetch"
          i18n:attributes="data-more-label more_link_label">
 
       <tal:EVENTS tal:replace="structure view/events_template" />

--- a/ftw/activity/tests/test_tab.py
+++ b/ftw/activity/tests/test_tab.py
@@ -18,7 +18,14 @@ class TestActivityView(TestCase):
         setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])
 
     @browsing
-    def test_fetch_more_events(self, browser):
+    def test_activity_fetch_url_points_to_activity_tab(self, browser):
+        browser.login().open(view='tabbed_view/listing?view_name=activity')
+        self.assertEquals(
+            'http://nohost/plone/tabbedview_view-activity/fetch',
+            browser.css('.events').first.attrib.get('data-fetch-url'))
+
+    @browsing
+    def test_render_events(self, browser):
         with freeze(datetime(2010, 1, 2)) as clock:
             create(Builder('page').titled('One'))
             clock.backward(days=1)
@@ -28,4 +35,11 @@ class TestActivityView(TestCase):
 
         browser.login().open(view='tabbedview_view-activity')
         self.assertEquals(['One', 'Two', 'Three'],
+                          map(attrgetter('title'), activity.events()))
+
+    @browsing
+    def test_fetch_is_traversable(self, browser):
+        create(Builder('page').titled('One'))
+        browser.login().open(view='tabbedview_view-activity/fetch')
+        self.assertEquals(['One'],
                           map(attrgetter('title'), activity.events()))

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ version = '2.0.1.dev0'
 
 tests_require = [
     'ftw.builder',
+    'ftw.tabbedview',
     'ftw.testbrowser',
     'ftw.testing',
     'plone.app.dexterity',


### PR DESCRIPTION
### Change rendered fetch URL

Change the rendered fetch URL to no longer be generated from the
request but to be built from the view name under which the activity view
is rendered.
This is done in order to make sure that we have the actually used
activity view which should allow public access to /fetch in order to
update with AJAX.

### Make /fetch and /raw traversable and public callable

The "fetch" and "raw" methods of any activity view should be public
callable in order to update views with AJAX.