### PR TITLE
Change js that adds/removes the more-button

### DIFF
--- a/ftw/activity/browser/templates/activity_raw.pt
+++ b/ftw/activity/browser/templates/activity_raw.pt
@@ -2,6 +2,7 @@
 
   <div class="activity">
     <div class="events"
+         tal:attributes="data-total python:len(view._lookup())"
          i18n:attributes="data-more-label more_link_label">
 
       <tal:EVENTS tal:replace="structure view/fetch" />

--- a/ftw/activity/resources/activity.js
+++ b/ftw/activity/resources/activity.js
@@ -12,8 +12,11 @@
     var more = $('<a />').
         attr('href', '#').
         addClass('more-button').
-        text(events.data('more-label')).
-        insertAfter(events);
+        text(events.data('more-label'));
+
+        if ($('.events').data('total') > events.find('.event').length) {
+          more.insertAfter(events)
+        }
 
     more.click(function(event) {
       event.preventDefault();
@@ -31,8 +34,9 @@
           $(data).appendTo(events);
           var new_events = events.find('.event').not(old_events);
           events.trigger('activity-fetched', [new_events]);
-        } else {
-          more.remove();
+          if ($('.events').data('total') == events.find('.event').length) {
+            more.remove()
+          }
         }
       });
     });


### PR DESCRIPTION
Changes the way the JS adds and removes the more-button.
Before this, the button was display, even if there were no more events to show. Now the button only gets displayed if there are more events available.
This change will only be available for my.teamraum!

closes https://github.com/4teamwork/my.teamraum/issues/563
