### PR TITLE
Hide "More" button when there are no events.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hide "More" button when there are no events. [jone]
 
 
 2.2.0 (2016-06-01)

--- a/ftw/activity/resources/activity.js
+++ b/ftw/activity/resources/activity.js
@@ -9,6 +9,10 @@
       return;
     }
 
+    if (events.find('.event').length === 0) {
+      return;
+    }
+
     var fetch_url = events.data('fetch-url');
     var more = $('<a />').
         attr('href', '#').


### PR DESCRIPTION
When there are no activities, there is no last activity and the "More" button is not working and leads to a ValueError.
This issue is fixed by not inserting the "More" button when there are no events at all.