### PR TITLE
Fix error in detection of last event (More button).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error in detection of last event (More button). [jone]
 
 
 2.2.1 (2016-11-15)

--- a/ftw/activity/browser/activity.py
+++ b/ftw/activity/browser/activity.py
@@ -80,13 +80,14 @@ class ActivityView(BrowserView):
         previous = None
         enumerated_activities = enumerate(activities)
         for index, repr in enumerated_activities:
-            if index >= amount:
-                break
             if previous is not None:
                 yield previous
 
             previous = {'activity': repr,
                         'is_last_activity': False}
+
+            if index >= amount - 1:
+                break
 
         if previous is not None:
             try:

--- a/ftw/activity/tests/test_activity_view.py
+++ b/ftw/activity/tests/test_activity_view.py
@@ -123,7 +123,7 @@ class TestActivityView(TestCase):
     def test_events_are_batched(self):
         pages = []
         with freeze(datetime(2010, 1, 2)) as clock:
-            for index in range(6):
+            for index in range(7):
                 clock.backward(hours=1)
                 pages.append(create(Builder('page')
                                     .titled('Page {0}'.format(index))))
@@ -142,7 +142,11 @@ class TestActivityView(TestCase):
         events = list(view.events(amount=3, last_activity=events[-1]['activity_id']))
         self.assertEquals([{'title': 'Page 3', 'is_last': False},
                            {'title': 'Page 4', 'is_last': False},
-                           {'title': 'Page 5', 'is_last': True}],
+                           {'title': 'Page 5', 'is_last': False}],
+                          map(activity_repr, events))
+
+        events = list(view.events(amount=3, last_activity=events[-1]['activity_id']))
+        self.assertEquals([{'title': 'Page 6', 'is_last': True}],
                           map(activity_repr, events))
 
     @browsing


### PR DESCRIPTION
Fixes the last event detection when on the next page is exactly one element.

The `enumerated_activities` was consumed too early.