### PR TITLE
Add version constraint for node.ext.zodb <= 1.0.1 to avoid pulling in ZODB 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='ftw.activity',
         'plone.api',
         'setuptools',
         'souper',
+        'node.ext.zodb <= 1.0.1',  # Avoid pulling in ZODB 5
         ],
 
       tests_require=tests_require,


### PR DESCRIPTION
`node.ext.zodb` is a dependency of `souper`, and after `node.ext.zodb == 1.0.1` they started working
on **ZODB 5** support, and actually pull in ZODB 5 (the `ZODB` egg, instead of
`ZODB3`).

See https://github.com/bluedynamics/node.ext.zodb/commit/741ce0bb for the commit that introduces the dependency on ZODB 5.

Should fix this test failure: https://ci.4teamwork.ch/builds/90375/tasks/131810#bottom

@jone @maethu 