### PR TITLE
Fix copy/paste of objects without UIDs by ignoring their events

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore events of objects without UIDs to avoid errors. [raphael-s]
 
 
 2.3.1 (2017-06-19)

--- a/ftw/activity/tests/test_uid_check.py
+++ b/ftw/activity/tests/test_uid_check.py
@@ -1,0 +1,35 @@
+from ftw.activity.subscribers import is_supported
+from ftw.activity.testing import FUNCTIONAL_TESTING
+from ftw.builder import Builder
+from ftw.builder import create
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+
+class TestUIDCheck(TestCase):
+    """ is_supported checks if the object of the event can be used
+        to create an activity event.
+        This prevents errors in Plone when moving objects whose actions
+        cannot be indexed by ftw.activity.
+    """
+
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+        self.portal = self.layer['portal']
+
+    def test_plone_site_is_not_supported(self):
+        self.assertFalse(is_supported(self.portal))
+
+    def test_scripts_are_not_supported(self):
+        # Example script from Plone
+        self.assertFalse(is_supported(self.portal.checkUpToDate))
+
+    # Test some default content types just in case
+    def test_file_is_supported(self):
+        self.assertTrue(is_supported(create(Builder('file'))))
+
+    def test_folder_is_supported(self):
+        self.assertTrue(is_supported(create(Builder('folder'))))


### PR DESCRIPTION
To create an ActivityRecord, the object which triggered the event needs to have a UID. If it does not, the ActivityRecord can't be created.

`ftw.activity` now checks if the object does have a UID before trying to create its ActivityRecord. This means that items without UIDs (Scripts, Plone Sites, etc) will never show up in the activity stream.

closes #23 