### PR TITLE
Ignore events fired by moving a plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore events fired by moving a plone site [raphael-s]
 
 
 2.3.2 (2017-07-03)

--- a/ftw/activity/subscribers.py
+++ b/ftw/activity/subscribers.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from ftw.activity.catalog import comment_added
 from ftw.activity.catalog import comment_removed
 from ftw.activity.catalog import object_added
@@ -18,7 +19,7 @@ def is_supported(context):
 
 
 def make_object_added_activity(context, event):
-    if not is_supported(context):
+    if not is_supported(context) or IPloneSiteRoot.providedBy(event.object):
         return None
 
     object_added(context)


### PR DESCRIPTION
When moving (copy/paste) a Plone site, `ftw.activity` could not create an ActivityRecord for the event. We now ignore events fired by moving a Plone site completely since they are irrelevant anyway.
